### PR TITLE
Test everything

### DIFF
--- a/quaternions/quaternions.py
+++ b/quaternions/quaternions.py
@@ -151,6 +151,7 @@ class Quaternion(object):
 
     @property
     def basis(self):
+        # TODO: deprecate basis, it is not used here and it can be obtained with matrix
         b0, b1, b2 = self.matrix
         return b0, b1, b2
 

--- a/quaternions/quaternions.py
+++ b/quaternions/quaternions.py
@@ -19,6 +19,7 @@ class Quaternion(object):
         self.qj = qj
         self.qk = qk
 
+        self.validate_numeric_stability = validate_numeric_stability
         if validate_numeric_stability:
             if self._squarenorm() < self.tolerance * self.tolerance:
                 raise QuaternionError('provided numerically unstable quaternion: %s' % self)
@@ -47,7 +48,8 @@ class Quaternion(object):
         elif isinstance(p, Iterable):
             return self.matrix.dot(p)
         else:
-            return Quaternion(self.qr * p, self.qi * p, self.qj * p, self.qk * p)
+            return Quaternion(self.qr * p, self.qi * p, self.qj * p, self.qk * p,
+                              validate_numeric_stability=self.validate_numeric_stability)
 
     def __rmul__(self, p):
         return self.__mul__(p)

--- a/quaternions/quaternions.py
+++ b/quaternions/quaternions.py
@@ -151,22 +151,7 @@ class Quaternion(object):
 
     @property
     def basis(self):
-        qr, qi, qj, qk = self.coordinates
-        b0 = np.array([
-            qr ** 2 + qi ** 2 - qj ** 2 - qk ** 2,
-            2 * qr * qk + 2 * qi * qj,
-            -2 * qr * qj + 2 * qi * qk
-        ])
-        b1 = np.array([
-            -2 * qr * qk + 2 * qi * qj,
-            qr ** 2 - qi ** 2 + qj ** 2 - qk ** 2,
-            2 * qr * qi + 2 * qj * qk
-        ])
-        b2 = np.array([
-            2 * qr * qj + 2 * qi * qk,
-            -2 * qr * qi + 2 * qj * qk,
-            qr ** 2 - qi ** 2 - qj ** 2 + qk ** 2
-        ])
+        b0, b1, b2 = self.matrix
         return b0, b1, b2
 
     @property

--- a/quaternions/quaternions.py
+++ b/quaternions/quaternions.py
@@ -114,7 +114,7 @@ class Quaternion(object):
         imag_norm = np.linalg.norm(imag)
         if imag_norm == 0:
             i_part = 0 if self.qr > 0 else np.pi
-            return Quaternion(np.log(norm), i_part, 0, 0)
+            return Quaternion(np.log(norm), i_part, 0, 0, validate_numeric_stability=False)
         imag = imag / imag_norm * np.arctan2(imag_norm, self.qr / norm)
         return Quaternion(np.log(norm), *imag)
 

--- a/quaternions/quaternions.py
+++ b/quaternions/quaternions.py
@@ -194,6 +194,7 @@ class Quaternion(object):
         Notice that Tetra gives a different roll angle, so this is not
         a fixed standard.
         '''
+        # TODO: deprecate this method; move it to projects that need it
         twisted = self.OpticalAxisFirst() * self
         ra, dec, roll = twisted.ra_dec_roll
         return np.array([-ra, dec, roll - 180])

--- a/tests/test_quaternions.py
+++ b/tests/test_quaternions.py
@@ -19,6 +19,12 @@ class QuaternionTest(unittest.TestCase):
         expected = Quaternion(0, 2, 4, 6)
         np.testing.assert_allclose(expected.coordinates, (q1 + q2).coordinates)
 
+    def test_subtraction(self):
+        q1 = Quaternion(1, 2, 3, 4)
+        q2 = Quaternion(-1, 0, 1, 2)
+        expected = Quaternion(2, 2, 2, 2)
+        np.testing.assert_allclose(expected.coordinates, (q1 - q2).coordinates)
+
     def test_matrix_respects_product(self):
         q1 = Quaternion.exp(Quaternion(0, .1, .02, -.3))
         q2 = Quaternion.exp(Quaternion(0, -.2, .21, .083))

--- a/tests/test_quaternions.py
+++ b/tests/test_quaternions.py
@@ -25,6 +25,13 @@ class QuaternionTest(unittest.TestCase):
         expected = Quaternion(2, 2, 2, 2)
         np.testing.assert_allclose(expected.coordinates, (q1 - q2).coordinates)
 
+    def test_repr(self):
+        q = Quaternion(0, 1, 2, 3)
+        r = repr(q)
+        obtained = eval(r)
+        assert isinstance(obtained, Quaternion)
+        np.testing.assert_allclose(q.coordinates, obtained.coordinates)
+
     def test_matrix_respects_product(self):
         q1 = Quaternion.exp(Quaternion(0, .1, .02, -.3))
         q2 = Quaternion.exp(Quaternion(0, -.2, .21, .083))

--- a/tests/test_quaternions.py
+++ b/tests/test_quaternions.py
@@ -351,7 +351,7 @@ class ParameterizedTests(unittest.TestCase):
         assert ~q == q.inverse() == q.conjugate()
         assert q * ~q == ~q * q == Quaternion.Unit()
 
-    @given(integers(min_value=1, max_value=5))
+    @given(integers(min_value=0, max_value=5))
     def test_integrate(self, number_of_vectors):
         vectors = [np.array([0, 0, i / 10]) for i in range(1, number_of_vectors + 1)]
         v = Quaternion.integrate_from_velocity_vectors(vectors)

--- a/tests/test_quaternions.py
+++ b/tests/test_quaternions.py
@@ -1,6 +1,6 @@
 import unittest
 from hypothesis import given, assume
-from hypothesis.strategies import floats
+from hypothesis.strategies import floats, integers
 import numpy as np
 
 from quaternions import Quaternion, QuaternionError
@@ -350,3 +350,10 @@ class ParameterizedTests(unittest.TestCase):
         q = Quaternion(qr, qi, qj, qk)
         assert ~q == q.inverse() == q.conjugate()
         assert q * ~q == ~q * q == Quaternion.Unit()
+
+    @given(integers(min_value=1, max_value=5))
+    def test_integrate(self, number_of_vectors):
+        vectors = [np.array([0, 0, i / 10]) for i in range(1, number_of_vectors + 1)]
+        v = Quaternion.integrate_from_velocity_vectors(vectors)
+        expected = [0, 0, number_of_vectors * (number_of_vectors + 1) / 20]
+        np.testing.assert_allclose(expected, v)

--- a/tests/test_quaternions.py
+++ b/tests/test_quaternions.py
@@ -13,6 +13,12 @@ class QuaternionTest(unittest.TestCase):
                                    [.357073, .325773, .875426]])
     schaub_result = np.array([.961798, -.14565, .202665, .112505])
 
+    def test_addition(self):
+        q1 = Quaternion(1, 2, 3, 4)
+        q2 = Quaternion(-1, 0, 1, 2)
+        expected = Quaternion(0, 2, 4, 6)
+        np.testing.assert_allclose(expected.coordinates, (q1 + q2).coordinates)
+
     def test_matrix_respects_product(self):
         q1 = Quaternion.exp(Quaternion(0, .1, .02, -.3))
         q2 = Quaternion.exp(Quaternion(0, -.2, .21, .083))

--- a/tests/test_quaternions.py
+++ b/tests/test_quaternions.py
@@ -73,6 +73,13 @@ class QuaternionTest(unittest.TestCase):
                 v2 = a1 * frame_2[0] + a2 * frame_2[1]
                 np.testing.assert_allclose(q.matrix.dot(v1), v2, atol=1e-10)
 
+    def test_qmethod_without_probs(self):
+        frame_1 = np.array([[2 / 3, 2 / 3, 1 / 3], [2 / 3, -1 / 3, -2 / 3]])
+        frame_2 = np.array([[0.8, 0.6, 0], [-0.6, 0.8, 0]])
+        q_prob = Quaternion.from_qmethod(frame_1.T, frame_2.T, np.ones(2))
+        q_noprob = Quaternion.from_qmethod(frame_1.T, frame_2.T)
+        assert q_prob == q_noprob
+
     def test_qmethod_with_probability(self):
         frame_1 = np.array([[2 / 3, 2 / 3, 1 / 3], [2 / 3, -1 / 3, -2 / 3]])
         frame_2 = np.array([[0.8, 0.6, 0], [-0.6, 0.8, 0]])


### PR DESCRIPTION
This leaves coverage at almost 100% except for two methods which should be deprecated:

- We should deprecate `basis`, which is a remnant from older days.
- We should also deprecate the untested method `astrometry_ra_dec_roll` and eventually remove it, as it does not belong to a general lib.