### PR TITLE
Numpy had an alias for Python's `math` module, it got removed

### DIFF
--- a/quaternions/quaternion.py
+++ b/quaternions/quaternion.py
@@ -1,14 +1,15 @@
-import functools
-import numpy as np
 from collections.abc import Iterable
+import functools
+import math
 import numbers
+import warnings
+
+import numpy as np
 
 from quaternions.utils import (covariance_matrix_from_angles, sigma_lerner, xi_matrix)
 from quaternions.general_quaternion import (
     GeneralQuaternion, QuaternionError, DEFAULT_TOLERANCE, exp
 )
-
-import warnings
 
 
 class Quaternion(GeneralQuaternion):
@@ -138,7 +139,7 @@ class Quaternion(GeneralQuaternion):
     def rotation_angle(self):
         """ returns rotation angle [rad], in [0, 2 * pi) """
         angle = np.linalg.norm(self.rotation_vector)
-        angle %= 2 * np.math.pi
+        angle %= 2 * math.pi
         return angle
 
     @property

--- a/tests/test_quaternion.py
+++ b/tests/test_quaternion.py
@@ -1,10 +1,11 @@
+import os
+import json
+import math
 import unittest
 
 from hypothesis import given, assume, strategies, example
 import numpy as np
 import pytest
-import os
-import json
 
 from quaternions import Quaternion, QuaternionError, GeneralQuaternion
 from quaternions.general_quaternion import DEFAULT_TOLERANCE, exp, log
@@ -42,11 +43,11 @@ class QuaternionTest(unittest.TestCase):
         assert q != q + Quaternion(1, 2, 3, 4)
         assert q == GeneralQuaternion(*q.coordinates)
 
-    @given(ANY_QUATERNION, strategies.floats(min_value=0, max_value=2 * np.math.pi-1e-4))
+    @given(ANY_QUATERNION, strategies.floats(min_value=0, max_value=2 * math.pi-1e-4))
     def test_distance(self, arr, angle_rad):
         assume(GeneralQuaternion(*arr).norm() > DEFAULT_TOLERANCE)
         q = Quaternion(*arr)
-        assert q.distance(-q) == pytest.approx(0) or q.distance(-q) == pytest.approx(2 * np.math.pi)
+        assert q.distance(-q) == pytest.approx(0) or q.distance(-q) == pytest.approx(2 * math.pi)
 
         for diff in [Quaternion.from_ra_dec_roll(np.degrees(angle_rad), 0, 0),
                      Quaternion.from_ra_dec_roll(0, np.degrees(angle_rad), 0),
@@ -94,7 +95,7 @@ class QuaternionTest(unittest.TestCase):
         np.testing.assert_allclose(complex_part / complex_norm, q.rotation_axis())
 
         # test alternative, direct way to calculate rotation angle:
-        angle = 2 * np.math.atan2(complex_norm, q.qr)
+        angle = 2 * math.atan2(complex_norm, q.qr)
         assert angle == pytest.approx(q.rotation_angle())
 
         # test rotation of q^2 is 2*rotation:


### PR DESCRIPTION
Fix for:
```
DeprecationWarning: `np.math` is a deprecated alias for the standard library `math` module (Deprecated Numpy 1.25). Replace usages of `np.math` with `math`
```